### PR TITLE
[FEAT] Add exam_batch count and exam_student count to the list view endpoint

### DIFF
--- a/admin_panel/exams/serializer.py
+++ b/admin_panel/exams/serializer.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from admin_panel.exams.model import Exam
 from admin_panel.organizations.serializer import OrganizationSerializer
+from django.db import models
 
 
 class ExamCreateSerializer(serializers.ModelSerializer):
@@ -47,6 +48,8 @@ class ExamSerializer(serializers.ModelSerializer):
 class ExamResponseSerializer(serializers.ModelSerializer):
     """Serializer for reading exam data"""
     organization = OrganizationSerializer(read_only=True)
+    batch_count = serializers.SerializerMethodField()
+    student_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Exam
@@ -64,6 +67,16 @@ class ExamResponseSerializer(serializers.ModelSerializer):
             'total_marks',
             'organization',
             'created_at',
-            'updated_at'
+            'updated_at',
+            'batch_count',
+            'student_count'
         ]
         read_only_fields = ['id', 'created_at', 'updated_at']
+
+    def get_batch_count(self, obj):
+        return obj.exam_batches.count()
+
+    def get_student_count(self, obj):
+        return obj.exam_batches.aggregate(
+            total_students=models.Count('exam_students')
+        )['total_students'] or 0

--- a/admin_panel/exams/serializer.py
+++ b/admin_panel/exams/serializer.py
@@ -77,6 +77,10 @@ class ExamResponseSerializer(serializers.ModelSerializer):
         return obj.exam_batches.count()
 
     def get_student_count(self, obj):
-        return obj.exam_batches.aggregate(
-            total_students=models.Count('exam_students')
-        )['total_students'] or 0
+        return getattr(
+            obj,
+            'student_count',
+            obj.exam_batches.aggregate(
+                total_students=models.Count('exam_students')
+            )['total_students'] or 0
+        )


### PR DESCRIPTION
Committer: Jeevan <justjeevan07@gmail.com> 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `ExamResponseSerializer` with new fields: `batch_count` and `student_count`.
	- Added methods to compute the number of exam batches and associated students for better exam insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Added batch_count and student_count fields to ExamResponseSerializer to provide aggregate information about exam batches and enrolled students. The implementation uses a simplified getattr approach for fetching student counts, optimizing the list view endpoint by eliminating additional API calls and reducing database queries.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>